### PR TITLE
Add formatting to non JSON messages

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -8,7 +8,7 @@ import os, sys, unittest, collections, copy, re
 print(sys.version)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from pycwl import *
+from watchtower import *
 from eight import *
 
 class TestPyCWL(unittest.TestCase):

--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -95,7 +95,7 @@ class CloudWatchLogHandler(handler_base_class):
                                logGroupName=self.log_group, logStreamName=stream_name)
             self.sequence_tokens[stream_name] = None
 
-        msg = dict(timestamp=int(message.created * 1000), message=message.msg)
+        msg = dict(timestamp=int(message.created * 1000), message=self.format(message))
         if isinstance(msg["message"], collections.Mapping):
             msg["message"] = json.dumps(msg["message"])
         if self.use_queues:


### PR DESCRIPTION
Messages that are sent to CW seem to not be formatted via the format string. This PR applies the format.

Below is a screenshot of CW on the log. First even is current format in master, second event is this PR applies. (File  path removed to comply with work)
![screen shot 2015-09-08 at 5 46 42 pm](https://cloud.githubusercontent.com/assets/413937/9749327/a97adffe-5651-11e5-8658-35814a1107bd.png)

Open to suggestions!