### PR TITLE
Additional fix for empty queue handling

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -132,7 +132,8 @@ class CloudWatchLogHandler(handler_base_class):
                 except Queue.Empty:
                     # If the queue is empty, we don't want to reprocess the previous message
                     msg = None
-                if msg == self.END \
+                if msg is None \
+                   or msg == self.END \
                    or cur_batch_size + size(msg) > max_batch_size \
                    or cur_batch_msg_count >= max_batch_count \
                    or time.time() >= cur_batch_deadline:


### PR DESCRIPTION
I missed one crucial change with my last PR, my apologies. With msg == None, size(msg) fails in the following if statement. This short circuits this by checking if the msg is None first, and then proceeding to send out a batch of logs. This shouldn't be any problem, as if the batch is empty, it's a noop, and if it's not empty, it should be time to send out the batch anyway, given that the queue timed out based on the next send interval.
