### PR TITLE
Connect to cloudwatch later in __init__

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -62,10 +62,10 @@ class CloudWatchLogHandler(handler_base_class):
         self.send_interval = send_interval
         self.max_batch_size = max_batch_size
         self.max_batch_count = max_batch_count
-        self.cwl_client = (boto3_session or boto3).client("logs")
         self.queues, self.sequence_tokens = {}, {}
         self.threads = []
         self.shutting_down = False
+        self.cwl_client = (boto3_session or boto3).client("logs")
         _idempotent_create(self.cwl_client.create_log_group, logGroupName=self.log_group)
 
     def _submit_batch(self, batch, stream_name):


### PR DESCRIPTION
This avoids an exception on shutdown if the connection to CloudWatch
fails (e.g. because of a botocore.exceptions.NoRegionError).

    Error in sys.exitfunc:
    Traceback (most recent call last):
    File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
       func(*targs, **kargs)
    File "/usr/lib/python2.7/logging/__init__.py", line 1661, in shutdown
       h.flush()
    File "/usr/lib/python2.7/dist-packages/watchtower/__init__.py", line 158, in flush
       for q in self.queues.values():
    AttributeError: 'CloudWatchLogHandler' object has no attribute 'queues'