### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Authors
 Links
 -----
 * `Project home page (GitHub) <https://github.com/kislyuk/watchtower>`_
-* `Documentation (Read the Docs) <https://watchtower.readthedocs.org/en/latest/>`_
+* `Documentation (Read the Docs) <https://watchtower.readthedocs.io/en/latest/>`_
 * `Package distribution (PyPI) <https://pypi.python.org/pypi/watchtower>`_
 * `AWS CLI CloudWatch Logs plugin <https://pypi.python.org/pypi/awscli-cwlogs>`_
 * `Docker awslogs adapter <https://github.com/docker/docker/blob/master/daemon/logger/awslogs/cloudwatchlogs.go>`_
@@ -106,4 +106,4 @@ Licensed under the terms of the `Apache License, Version 2.0 <http://www.apache.
 .. image:: https://img.shields.io/pypi/l/watchtower.svg
         :target: https://pypi.python.org/pypi/watchtower
 .. image:: https://readthedocs.org/projects/watchtower/badge/?version=latest
-        :target: https://watchtower.readthedocs.org/
+        :target: https://watchtower.readthedocs.io/

--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -136,7 +136,7 @@ class CloudWatchLogHandler(handler_base_class):
         def size(msg):
             return len(msg["message"]) + 26
 
-        # See https://boto3.readthedocs.org/en/latest/reference/services/logs.html#logs.Client.put_log_events
+        # See https://boto3.readthedocs.io/en/latest/reference/services/logs.html#CloudWatchLogs.Client.put_log_events
         while msg != self.END:
             cur_batch = [] if msg is None else [msg]
             cur_batch_size = sum(size(msg) for msg in cur_batch)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.