### PR TITLE
Handle retries exhausted situation gracefully

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -85,6 +85,7 @@ class CloudWatchLogHandler(handler_base_class):
                       logEvents=sorted_batch)
         if self.sequence_tokens[stream_name] is not None:
             kwargs["sequenceToken"] = self.sequence_tokens[stream_name]
+        response = None
 
         for retry in range(max_retries):
             try:
@@ -97,7 +98,8 @@ class CloudWatchLogHandler(handler_base_class):
                 else:
                     raise
 
-        if "rejectedLogEventsInfo" in response:
+        # response can be None only when all retries have been exhausted
+        if response is None or "rejectedLogEventsInfo" in response:
             # TODO: make this configurable/non-fatal
             raise Exception("Failed to deliver logs: {}".format(response))
 


### PR DESCRIPTION
Hi!

In some rare cases response can be None, _send_batch should handle gracefully.

Also, it's possible to send very large message (larger than clowdwatch limit), which leads to delivery failure. To still be able to deliver something, it's worth to truncate such messages.
