### PR TITLE
Possible string substitution in stream_name

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -31,7 +31,7 @@ class CloudWatchLogHandler(handler_base_class):
     :type log_group: String
     :param stream_name:
         Name of the CloudWatch log stream to write logs to. By default, the name of the logger that processed the
-        message is used.
+        message is used. Accepts a format string parameter of {logger_name}. 
     :type stream_name: String
     :param use_queues:
         If **True**, logs will be queued on a per-stream basis and sent in batches. To manage the queues, a queue
@@ -110,6 +110,8 @@ class CloudWatchLogHandler(handler_base_class):
         stream_name = self.stream_name
         if stream_name is None:
             stream_name = message.name
+        else:
+            stream_name = stream_name.foramt(logger_name = message.name)
         if stream_name not in self.sequence_tokens:
             _idempotent_create(self.cwl_client.create_log_stream,
                                logGroupName=self.log_group, logStreamName=stream_name)

--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -31,7 +31,7 @@ class CloudWatchLogHandler(handler_base_class):
     :type log_group: String
     :param stream_name:
         Name of the CloudWatch log stream to write logs to. By default, the name of the logger that processed the
-        message is used. Accepts a format string parameter of {logger_name}. 
+        message is used. Accepts a format string parameter of {logger_name}.
     :type stream_name: String
     :param use_queues:
         If **True**, logs will be queued on a per-stream basis and sent in batches. To manage the queues, a queue
@@ -111,7 +111,7 @@ class CloudWatchLogHandler(handler_base_class):
         if stream_name is None:
             stream_name = message.name
         else:
-            stream_name = stream_name.format(logger_name = message.name)
+            stream_name = stream_name.format(logger_name=message.name)
         if stream_name not in self.sequence_tokens:
             _idempotent_create(self.cwl_client.create_log_stream,
                                logGroupName=self.log_group, logStreamName=stream_name)

--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -111,7 +111,7 @@ class CloudWatchLogHandler(handler_base_class):
         if stream_name is None:
             stream_name = message.name
         else:
-            stream_name = stream_name.foramt(logger_name = message.name)
+            stream_name = stream_name.format(logger_name = message.name)
         if stream_name not in self.sequence_tokens:
             _idempotent_create(self.cwl_client.create_log_stream,
                                logGroupName=self.log_group, logStreamName=stream_name)


### PR DESCRIPTION
I wanted my stream names to include the instance ID as a prefix, but still use the logger name. This patch performs a string substition of `{logger_name}` if it's in the `stream_name` variable. 