### PR TITLE
If message is a dict send json dumps

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -118,8 +118,8 @@ class CloudWatchLogHandler(handler_base_class):
             self.sequence_tokens[stream_name] = None
 
         msg = dict(timestamp=int(message.created * 1000), message=self.format(message))
-        if isinstance(msg["message"], collections.Mapping):
-            msg["message"] = json.dumps(msg["message"])
+        if isinstance(message.msg, collections.Mapping):
+            msg["message"] = json.dumps(message.msg)
         if self.use_queues:
             if stream_name not in self.queues:
                 self.queues[stream_name] = Queue.Queue()


### PR DESCRIPTION
I was using his library but wasn't getting JSON on CloudWatch. I also tested with your sample code from the README and it was outputing as string to CloudWatch. 

This path will allow dictionaries to be sent correctly as json which will allow you to search using this like `{$.status_code = 200}`.

To test this just run the code from the README and after the log reaches CloudWatch search using `{$.foo = "bar"}`.

Thanks a lot for your work on this.