### PR TITLE
support for django log

### DIFF
--- a/watchtower/django.py
+++ b/watchtower/django.py
@@ -10,7 +10,6 @@ class DjangoCloudWatchLogHandler(CloudWatchLogHandler):
     """
 
     def __init__(self, *args, **kwargs):
-        super(DjangoCloudWatchLogHandler, self).__init__(*args, **kwargs)
 
         client_kwargs = {}
         if hasattr(settings, 'AWS_ACCESS_KEY_ID'):
@@ -28,4 +27,6 @@ class DjangoCloudWatchLogHandler(CloudWatchLogHandler):
                 'region_name': getattr(settings, 'AWS_DEFAULT_REGION'),
             })
 
-        self.cwl_client = (kwargs.get('boto3_session') or boto3).client('logs', **client_kwargs)
+        kwargs['boto3_session'] = boto3.session.Session(**client_kwargs)
+
+        super(DjangoCloudWatchLogHandler, self).__init__(*args, **kwargs)

--- a/watchtower/django.py
+++ b/watchtower/django.py
@@ -1,0 +1,31 @@
+# coding: utf-8
+import boto3
+from django.conf import settings
+from watchtower import CloudWatchLogHandler
+
+
+class DjangoCloudWatchLogHandler(CloudWatchLogHandler):
+    """
+    Use the AWS variable configurations from the django settings.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(DjangoCloudWatchLogHandler, self).__init__(*args, **kwargs)
+
+        client_kwargs = {}
+        if hasattr(settings, 'AWS_ACCESS_KEY_ID'):
+            client_kwargs.update({
+                'aws_access_key_id': getattr(settings, 'AWS_ACCESS_KEY_ID'),
+            })
+
+        if hasattr(settings, 'AWS_SECRET_ACCESS_KEY'):
+            client_kwargs.update({
+                'aws_secret_access_key': getattr(settings, 'AWS_SECRET_ACCESS_KEY'),
+            })
+
+        if hasattr(settings, 'AWS_DEFAULT_REGION'):
+            client_kwargs.update({
+                'region_name': getattr(settings, 'AWS_DEFAULT_REGION'),
+            })
+
+        self.cwl_client = (kwargs.get('boto3_session') or boto3).client('logs', **client_kwargs)


### PR DESCRIPTION
Use the default django settings variables for AWS to connect to a custom log group and stream.

Must provide at the settings file the following variables (which are default for boto)

- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- AWS_DEFAULT_REGION