### PR TITLE
Enhancement: boto3 auth profile option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash
 
 test_deps:
-	pip install coverage flake8 wheel
+	pip install coverage flake8 wheel pyyaml mock boto3
 
 lint: test_deps
 	./setup.py flake8

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,125 @@ visualize it, and an alarm that sends an email::
 
     TODO
 
+Examples: Python Logging Config
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Python has the ability to provide a configuration file that can be loaded in order to separate the logging
+configuration from the code. Historically, Python has used the `logging.config.fileConfig` function to do
+so, however, that feature lacks the ability to use keyword args. Python 2.7 introduced a new feature to
+handle logging that is more robust - `logging.config.dictConfig` which profiles the ability to do more
+advanced Filters, but more importantly adds keyword args, thus allowing the `logging.config` functionality
+to instantiate Watchtower.
+
+The following are two example YAML configuration files that can be loaded using `PyYaml`. The resulting
+`dict` object can then be loaded into `logging.config.dictConfig`. The first example is a basic example
+that relies on the default configuration provided by `boto3`:
+
+.. code-block:: yaml
+    # Default AWS Config
+    version: 1
+    formatters:
+        json:
+            format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"
+        plaintext:
+            format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"
+    handlers:
+        console:
+            (): logging.StreamHandler
+            level: DEBUG
+            formatter: plaintext
+            stream: sys.stdout
+        watchtower:
+            formatter: json
+            level: DEBUG
+            (): watchtower.CloudWatchLogHandler
+            log_group: logger
+            stream_name:  loggable
+            send_interval: 1
+            create_log_group: False
+    loggers:
+        root:
+            handlers: [console, watchtower, logfile]
+        boto:
+            handlers: [console]
+        boto3:
+            handlers: [console]
+        botocore:
+            handlers: [console]
+        requests:
+            handlers: [console]
+
+
+The above works well if you can use the default configuration, or rely on environmental variables.
+However, sometimes one may want to use different credentials for logging than used for other functionality;
+in this case the `boto3_profile_name` option to Watchtower can be used to profile a profile name:
+
+.. code-block:: yaml
+    # AWS Config Profile
+    version: 1
+    formatters:
+        json:
+            format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"
+        plaintext:
+            format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"
+    handlers:
+        console:
+            (): logging.StreamHandler
+            level: DEBUG
+            formatter: plaintext
+            stream: sys.stdout
+        watchtower:
+            formatter: json
+            level: DEBUG
+            (): watchtower.CloudWatchLogHandler
+            log_group: logger
+            stream_name:  loggable
+            boto3_profile_name: watchtowerlogger
+            send_interval: 1
+            create_log_group: False
+    loggers:
+        root:
+            handlers: [console, watchtower, logfile]
+        boto:
+            handlers: [console]
+        boto3:
+            handlers: [console]
+        botocore:
+            handlers: [console]
+        requests:
+            handlers: [console]
+
+For the more advanced configuration, the following configuration file will profile
+the matching credentials to the `watchtowerlogger` profile:
+
+.. code-block:: cfg
+    [profile watchtowerlogger]
+    aws_access_key_id=MyAwsAccessKey
+    aws_secret_access_key=MyAwsSecretAccessKey
+    region=us-east-1
+
+Finally, the following shows how to load the configuration into the working application:
+
+.. code-block:: python
+
+    import logging.config
+
+    import flask
+    import yaml
+
+    app = flask.Flask("loggable")
+
+    @app.route('/')
+    def hello_world():
+        return 'Hello World!'
+
+    if __name__ == '__main__':
+        with open('logging.yml', 'r') as log_config:
+            config_yml = log_config.read()
+            config_dict = yaml.load(config_yml)
+            logging.config.dictConfig(config_dict)
+            app.run()
+
 Authors
 -------
 * Andrey Kislyuk

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 eight >= 0.3.0
 flake8
+PyYaml

--- a/test/logging.yml
+++ b/test/logging.yml
@@ -1,0 +1,17 @@
+# Default AWS Config
+version: 1
+formatters:
+    json:
+        format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"
+    plaintext:
+        format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"
+handlers:
+    watchtower:
+        formatter: json
+        level: DEBUG
+        (): watchtower.CloudWatchLogHandler
+        log_group: logger
+        stream_name:  loggable
+loggers:
+    root:
+        handlers: [watchtower]

--- a/test/logging_profile.yml
+++ b/test/logging_profile.yml
@@ -1,0 +1,18 @@
+# AWS Config Profile
+version: 1
+formatters:
+    json:
+        format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"
+    plaintext:
+        format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"
+handlers:
+    watchtower:
+        formatter: json
+        level: DEBUG
+        (): watchtower.CloudWatchLogHandler
+        log_group: logger
+        stream_name:  loggable
+        boto3_profile_name: watchtowerlogger
+loggers:
+    root:
+        handlers: [watchtower]

--- a/test/test.py
+++ b/test/test.py
@@ -3,14 +3,29 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os, sys, unittest, collections, copy, re
+import collections
+import copy
+import mock
+import logging
+import logging.config
+import os
+import os.path
+import re
+import sys
+import tempfile
+import unittest
+
+import botocore.configloader
+import yaml
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from watchtower import *
 
 class TestPyCWL(unittest.TestCase):
     def setUp(self):
-        pass
+        self.test_path = os.path.dirname(__file__)
+        self.log_config_yaml_basic = '{0}/logging.yml'.format(self.test_path)
+        self.log_config_yaml_profile = '{0}/logging_profile.yml'.format(self.test_path)
 
     def test_basic_pycwl_statements(self):
         h = CloudWatchLogHandler()
@@ -49,6 +64,56 @@ class TestPyCWL(unittest.TestCase):
     def test_multiple_handlers(self):
         # FIXME: multiple active CloudWatchLogHandlers cause daemon thread crashes at exit. This can probably be fixed with thread locals.
         pass
+
+    def test_logconfig_dictconfig_basic(self):
+        with open(self.log_config_yaml_basic, 'r') as yaml_input:
+            config_yml = yaml_input.read()
+            config_dict = yaml.load(config_yml)
+            logging.config.dictConfig(config_dict)
+            logger = logging.getLogger('root')
+            for i in range(10):
+                logger.critical(dict(src="foo2", event=str(i), stack=[1, 2, 3, i], details={}))
+
+    def test_logconfig_dictconfig_profile(self):
+        # NOTE: The below is a bit of a hack to get around how Travis-CI works so that it
+        #   can be fully tested remotely too.
+
+        # save the known configuration values from the ENV vars to a configuration file
+        aws_config = tempfile.NamedTemporaryFile()
+        with open(aws_config.name, 'w') as boto3_config_file:
+            boto3_config_file.write('[profile watchtowerlogger]\n')
+            boto3_config_file.write(
+                'aws_access_key_id={0}\n'.format(
+                    os.environ['AWS_ACCESS_KEY_ID']
+                )
+            )
+            boto3_config_file.write(
+                'aws_secret_access_key={0}\n'.format(
+                    os.environ['AWS_SECRET_ACCESS_KEY']
+                )
+            )
+            boto3_config_file.write(
+                'region={0}\n'.format(
+                    os.environ['AWS_DEFAULT_REGION']
+                )
+            )
+
+        # load them in order to have the same data format
+        config_data = botocore.configloader.load_config(aws_config.name)
+        # now mock out the botocore configuration loader in order to guarantee
+        # the correct data is loaded
+        with mock.patch('botocore.configloader.load_config') as boto_config:
+            boto_config.return_value = config_data
+
+            with open(self.log_config_yaml_profile, 'r') as yaml_input:
+                config_yml = yaml_input.read()
+                config_dict = yaml.load(config_yml)
+                logging.config.dictConfig(config_dict)
+                logger = logging.getLogger('root')
+                for i in range(10):
+                    logger.critical(dict(src="foo3", event=str(i), stack=[1, 2, 3, i], details={}))
+                boto_config.assert_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It would be extremely helpful to be able to configure watchtower via `logging.config`.
Due to the use of kwargs it's not possible to use the INI format availble via `logging.config.fileConfig`, however, the newer `logging.config.dictConfig` supports the kwargs which for the most part will work _unless_ watchtower needs to use a configuration profile that is not the default profile.

The advantage of being able to configure watchtower via `logging.config.dictConfig` is that it also makes setting the formatter, and other advanced functionality available via logging simpler:

```yaml
version: 1
formatters:
    plaintext:
        format: "[%(asctime)s] %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"
handlers:
    console:
        (): logging.StreamHandler
        level: DEBUG
        formatter: plaintext
        stream: sys.stdout
    watchtower:
        formatter: plaintext
        level: DEBUG
        (): watchtower.CloudWatchLogHandler
        log_group: myloggroup
        boto3_profile_name: myprofile
        stream_name: mystreamname
        send_interval: 1
        create_log_group: False

loggers:
    root: 
        handlers: [ watchtower, console ]
    boto:
        handlers: [ console ]
    boto3:
        handlers: [ console ]
    botocore:
        handlers: [ console ]
    requests:
        handlers: [ console ]
```
the `boto3_profile_name` refers to the profile in `~/.aws/config`:
```INI
[profile myprofile]
aws_access_key_id=<access_key>
aws_secret_access_key=<aws_secret_access_key>
region=<aws region>
```
This is helpful when you need to do this cross-account, like using AssumeRole, so that logs can go back into the primary account even though other functionality may be going to the other account.

Addresses Issue #40