### PR TITLE
Add mock to test-requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 eight >= 0.3.0
 flake8
 PyYaml
+mock


### PR DESCRIPTION
The `mock` package was missing from test-requirements.txt, leading to a `ModuleNotFoundError` when running `test/test.py`.

This PR simply adds the missing dependency to test-requirements.txt.