### PR TITLE
Define all instance attributes before attempting to create boto session

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -105,10 +105,13 @@ class CloudWatchLogHandler(handler_base_class):
         self.max_batch_count = max_batch_count
         self.queues, self.sequence_tokens = {}, {}
         self.threads = []
+        self.creating_log_stream, self.shutting_down = False, False
+
+        # Creating session should be the final call in __init__, after all instance attributes are set.
+        # This ensures that failing to create the session will not result in any missing attribtues.
         self.cwl_client = self._get_session(boto3_session, boto3_profile_name).client("logs")
         if create_log_group:
             _idempotent_create(self.cwl_client.create_log_group, logGroupName=self.log_group)
-        self.creating_log_stream, self.shutting_down = False, False
 
     def _submit_batch(self, batch, stream_name, max_retries=5):
         if len(batch) < 1:


### PR DESCRIPTION
When django shuts down, it calls `.flush()` on all handlers defined in `logging._handlerList` -- this handler list contains weak refs to all instantiated logging handlers.

If the cloud watch log handler was instantiated but then failed to establish its session, a boto exception (or some other exception) will be raised. But if someone has intentionally chosen to pass on these Exceptions when setting up the Cloud Watch handler and continue with some "back up" handler, you will hit an error like this during Django shutdown:
```
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "https://logs.bogus.amazonaws.com/"

Traceback (most recent call last):
  File "service.py", line 136, in <module>
    django.setup()
  File "/home/bsquizza/.local/share/virtualenvs/insights-advisor-service-LXzZpbPX/lib/python3.6/site-packages/django/__init__.py", line 19, in setup
    configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
  File "/home/bsquizza/.local/share/virtualenvs/insights-advisor-service-LXzZpbPX/lib/python3.6/site-packages/django/utils/log.py", line 72, in configure_logging
    logging.config.dictConfig(DEFAULT_LOGGING)
  File "/usr/lib64/python3.6/logging/config.py", line 802, in dictConfig
    dictConfigClass(config).configure()
  File "/usr/lib64/python3.6/logging/config.py", line 538, in configure
    _clearExistingHandlers()
  File "/usr/lib64/python3.6/logging/config.py", line 275, in _clearExistingHandlers
    logging.shutdown(logging._handlerList[:])
  File "/usr/lib64/python3.6/logging/__init__.py", line 1945, in shutdown
    h.flush()
  File "/home/bsquizza/.local/share/virtualenvs/insights-advisor-service-LXzZpbPX/lib/python3.6/site-packages/watchtower/__init__.py", line 203, in flush
    if self.shutting_down:
AttributeError: 'CloudWatchLogHandler' object has no attribute 'shutting_down'
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib64/python3.6/logging/__init__.py", line 1945, in shutdown
    h.flush()
  File "/home/bsquizza/.local/share/virtualenvs/insights-advisor-service-LXzZpbPX/lib/python3.6/site-packages/watchtower/__init__.py", line 203, in flush
    if self.shutting_down:
AttributeError: 'CloudWatchLogHandler' object has no attribute 'shutting_down'
```

This is because `self.shutting_down` is set on the instance after attempting to establish the session. This issue is avoided by defining all instance attributes BEFORE trying to establish the session.