### PR TITLE
adding ability to pass through cloudwatch logs endpoint url to boto3

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -75,6 +75,9 @@ class CloudWatchLogHandler(handler_base_class):
         https://docs.python.org/3/library/json.html#json.dump
         https://docs.python.org/2/library/json.html#json.dump
     :type json_serialize_default: Function
+    :param cloudwatch_logs_endpoint_url:
+        Passes through the specified cloudwatch logs endpoint to use with the boto3 cloudwatch log client.  **None** by default.
+    :type cloudwatch_logs_endpoint_url: String
     """
     END = 1
     FLUSH = 2
@@ -94,7 +97,7 @@ class CloudWatchLogHandler(handler_base_class):
 
     def __init__(self, log_group=__name__, stream_name=None, use_queues=True, send_interval=60,
                  max_batch_size=1024*1024, max_batch_count=10000, boto3_session=None,
-                 boto3_profile_name=None, create_log_group=True, json_serialize_default=None, *args, **kwargs):
+                 boto3_profile_name=None, create_log_group=True, json_serialize_default=None, cloudwatch_logs_endpoint_url=None, *args, **kwargs):
         handler_base_class.__init__(self, *args, **kwargs)
         self.log_group = log_group
         self.stream_name = stream_name
@@ -109,7 +112,7 @@ class CloudWatchLogHandler(handler_base_class):
 
         # Creating session should be the final call in __init__, after all instance attributes are set.
         # This ensures that failing to create the session will not result in any missing attribtues.
-        self.cwl_client = self._get_session(boto3_session, boto3_profile_name).client("logs")
+        self.cwl_client = self._get_session(boto3_session, boto3_profile_name).client("logs", endpoint_url=cloudwatch_logs_endpoint_url)
         if create_log_group:
             _idempotent_create(self.cwl_client.create_log_group, logGroupName=self.log_group)
 


### PR DESCRIPTION
Thank you for providing this library. I need the ability to configure the cloudwatch logs endpoint from the default boto3 configuration. Let me know if there are any additions needed to include this in the core library.