### PR TITLE
Cache messages on lack of internet connection

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -195,10 +195,9 @@ class CloudWatchLogHandler(handler_base_class):
 
         #------ operate on cache
         self.messages_cache.put((int(message.created * 1000), self.format(message)))
-        with self.messages_cache.mutex:
-            cwl_messages = []
-            while not self.messages_cache.empty():
-                cwl_messages.append(self.messages_cache.get())
+        cwl_messages = []
+        while not self.messages_cache.empty():
+            cwl_messages.append(self.messages_cache.get())
 
         #------ process messages
         for cwl_message in cwl_messages:

--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -3,7 +3,10 @@ from datetime import date, datetime
 from operator import itemgetter
 import json, logging, time, threading, warnings
 
-import queue
+try:
+    import queue
+except ImportError:	
+    import Queue as queue
 
 try:
     from collections.abc import Mapping

--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -139,9 +139,9 @@ class CloudWatchLogHandler(handler_base_class):
 
 
     def _submit_batch(self, batch, stream_name, max_retries=5):
-        if len(batch) < 1:
-            return
         ret = []
+        if len(batch) < 1:
+            return ret
         sorted_batch = sorted(batch, key=lambda x: x[0], reverse=False)
         kwargs = dict(logGroupName=self.log_group, logStreamName=stream_name,
                       logEvents=[{'timestamp':t,'message':m} for t,m in sorted_batch])

--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -5,7 +5,7 @@ import json, logging, time, threading, warnings
 
 try:
     import queue
-except ImportError:	
+except ImportError:
     import Queue as queue
 
 try:
@@ -160,7 +160,7 @@ class CloudWatchLogHandler(handler_base_class):
                     kwargs["sequenceToken"] = e.response["Error"]["Message"].rsplit(" ", 1)[-1]
                 else:
                     warnings.warn("Failed to deliver logs: {}".format(e), WatchtowerWarning)
-                    ret = sorted_batch
+                ret = sorted_batch
             except Exception as e:
                 warnings.warn("Failed to deliver logs: {}".format(e), WatchtowerWarning)
                 ret = sorted_batch


### PR DESCRIPTION
It is really important to recover logs after a network disconnection.
This fix uses a PriorityQueue to cache messages that failed to deliver to then retry.
If the process is started without an internet connection, an exception is raised if aws resources need to be created i.e. `log group`, `log group retention policy` and `log stream`: this fix also handles cacheing messages when the process is started without an internet connection, it pushes back the initialisation to the next call to `emit` before retrying and sending cached log events when finally successful.