### PR TITLE
Make serialize dictionary optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash
 
 test_deps:
-	pip install coverage flake8 wheel pyyaml mock boto3
+	pip install coverage flake8 wheel pyyaml mock boto3 structlog
 
 lint: test_deps
 	./setup.py flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ eight >= 0.3.0
 flake8
 PyYaml
 mock
+structlog


### PR DESCRIPTION
This pull request makes the dumps serialization step prior to formatting optional by introducing a new constructor param `serialize_dicts`. `serialize_dicts` defaults to True, which should make this change transparent to existing users.

The motivation for this change is to better support [structlog](https://www.structlog.org/en/stable/), which passes a dictionary to the logging handler and relies on the formatter to serialize that dictionary to a string. 