### PR TITLE
Create log streams lazily

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -153,6 +153,15 @@ class CloudWatchLogHandler(handler_base_class):
                 if e.response.get("Error", {}).get("Code") in ("DataAlreadyAcceptedException",
                                                                "InvalidSequenceTokenException"):
                     kwargs["sequenceToken"] = e.response["Error"]["Message"].rsplit(" ", 1)[-1]
+                elif e.response["Error"]["Code"] == "ResourceNotFoundException":
+                    if self.create_log_stream:
+                        self.creating_log_stream = True
+                        try:
+                            _idempotent_create(self.cwl_client.create_log_stream,
+                                               logGroupName=self.log_group,
+                                               logStreamName=stream_name)
+                        finally:
+                            self.creating_log_stream = False
                 else:
                     warnings.warn("Failed to deliver logs: {}".format(e), WatchtowerWarning)
             except Exception as e:
@@ -171,17 +180,7 @@ class CloudWatchLogHandler(handler_base_class):
         else:
             stream_name = stream_name.format(logger_name=message.name, strftime=datetime.utcnow())
         if stream_name not in self.sequence_tokens:
-            if self.create_log_stream:
-                self.creating_log_stream = True
-                try:
-                    _idempotent_create(self.cwl_client.create_log_stream,
-                                       logGroupName=self.log_group,
-                                       logStreamName=stream_name)
-                    self.sequence_tokens[stream_name] = None
-                finally:
-                    self.creating_log_stream = False
-            else:
-                self.sequence_tokens[stream_name] = None
+            self.sequence_tokens[stream_name] = None
 
         if isinstance(message.msg, Mapping):
             message.msg = json.dumps(message.msg, default=self.json_serialize_default)


### PR DESCRIPTION
Assume log streams exist when emitting the log, this avoids making a
request to create the log stream when a logger emits an event after the
process starts up.

In my use case, Python processes are spawned to react to an event, e.g.
a file was uploaded to S3. On the first upload, the log stream must be
created. For all subsequent uploads however, the log stream can be
assumed to exist.

Also, when spawning multiple processes quickly, e.g. in reaction to many
files being uploaded, AWS throttles the create_log_stream operation,
replying with:

```
ClientError in <my_process>
An error occurred (ThrottlingException) when calling the CreateLogStream
operation (reached max retries: 4): Rate exceeded
```

That response is not handled by the logger and crashes the Python process.