### PR TITLE
Drop compatibility for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash
 
 test_deps:
-	pip install coverage flake8 wheel pyyaml mock boto3
+	pip install coverage flake8 wheel pyyaml boto3
 
 lint: test_deps
 	./setup.py flake8

--- a/README.rst
+++ b/README.rst
@@ -82,12 +82,12 @@ This is an example of Watchtower integration with Django. In your Django project
         },
         'formatters': {
             'simple': {
-                'format': u"%(asctime)s [%(levelname)-8s] %(message)s",
+                'format': "%(asctime)s [%(levelname)-8s] %(message)s",
                 'datefmt': "%Y-%m-%d %H:%M:%S"
             },
             'aws': {
                 # you can add specific format for aws here
-                'format': u"%(asctime)s [%(levelname)-8s] %(message)s",
+                'format': "%(asctime)s [%(levelname)-8s] %(message)s",
                 'datefmt': "%Y-%m-%d %H:%M:%S"
             },
         },

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Watchtower'
-copyright = u'2014, Andrey Kislyuk'
+project = 'Watchtower'
+copyright = '2014, Andrey Kislyuk'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -183,8 +183,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Watchtower.tex', u'Watchtower Documentation',
-   u'Andrey Kislyuk', 'manual'),
+  ('index', 'Watchtower.tex', 'Watchtower Documentation',
+   'Andrey Kislyuk', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -213,8 +213,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'Watchtower', u'Watchtower Documentation',
-     [u'Andrey Kislyuk'], 1)
+    ('index', 'Watchtower', 'Watchtower Documentation',
+     ['Andrey Kislyuk'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -227,8 +227,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'watchtower', u'Watchtower Documentation',
-   u'Andrey Kislyuk', 'Watchtower', 'One line description of project.',
+  ('index', 'watchtower', 'Watchtower Documentation',
+   'Andrey Kislyuk', 'Watchtower', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 eight >= 0.3.0
 flake8
 PyYaml
-mock

--- a/test/test.py
+++ b/test/test.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
-# coding: utf-8
 
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 import collections
 import copy
 from datetime import datetime
 
-import mock
+from unittest import mock
 import logging
 import logging.config
 import os
@@ -25,14 +23,12 @@ import yaml
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))  # noqa
 from watchtower import CloudWatchLogHandler
 
-USING_PYTHON2 = True if sys.version_info < (3, 0) else False
-
 
 class TestPyCWL(unittest.TestCase):
     def setUp(self):
         self.test_path = os.path.dirname(__file__)
-        self.log_config_yaml_basic = '{0}/logging.yml'.format(self.test_path)
-        self.log_config_yaml_profile = '{0}/logging_profile.yml'.format(self.test_path)
+        self.log_config_yaml_basic = '{}/logging.yml'.format(self.test_path)
+        self.log_config_yaml_profile = '{}/logging_profile.yml'.format(self.test_path)
 
     def test_basic_pycwl_statements(self):
         h = CloudWatchLogHandler()
@@ -82,7 +78,7 @@ class TestPyCWL(unittest.TestCase):
         pass
 
     def test_logconfig_dictconfig_basic(self):
-        with open(self.log_config_yaml_basic, 'r') as yaml_input:
+        with open(self.log_config_yaml_basic) as yaml_input:
             config_yml = yaml_input.read()
             config_dict = yaml.load(config_yml, Loader=yaml.SafeLoader)
             logging.config.dictConfig(config_dict)
@@ -99,17 +95,17 @@ class TestPyCWL(unittest.TestCase):
         with open(aws_config.name, 'w') as boto3_config_file:
             boto3_config_file.write('[profile watchtowerlogger]\n')
             boto3_config_file.write(
-                'aws_access_key_id={0}\n'.format(
+                'aws_access_key_id={}\n'.format(
                     boto3.Session().get_credentials().access_key
                 )
             )
             boto3_config_file.write(
-                'aws_secret_access_key={0}\n'.format(
+                'aws_secret_access_key={}\n'.format(
                     boto3.Session().get_credentials().secret_key
                 )
             )
             boto3_config_file.write(
-                'region={0}\n'.format(
+                'region={}\n'.format(
                     boto3.Session().region_name
                 )
             )
@@ -121,7 +117,7 @@ class TestPyCWL(unittest.TestCase):
         with mock.patch('botocore.configloader.load_config') as boto_config:
             boto_config.return_value = config_data
 
-            with open(self.log_config_yaml_profile, 'r') as yaml_input:
+            with open(self.log_config_yaml_profile) as yaml_input:
                 config_yml = yaml_input.read()
                 config_dict = yaml.load(config_yml, Loader=yaml.SafeLoader)
                 logging.config.dictConfig(config_dict)
@@ -133,7 +129,7 @@ class TestPyCWL(unittest.TestCase):
     def test_terminating_process(self):
         cwd = os.path.dirname(__file__)
         proc = subprocess.Popen(['python', 'run_logging.py'], cwd=cwd)
-        proc.wait() if USING_PYTHON2 else proc.wait(10)
+        proc.wait(10)
 
     def test_empty_message(self):
         handler = CloudWatchLogHandler(use_queues=False)

--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -1,17 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+from collections.abc import Mapping
 from datetime import date, datetime
 from operator import itemgetter
 import json, logging, time, threading, warnings
-
-try:
-    import queue
-except ImportError:
-    import Queue as queue
-
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+import queue
 
 import boto3
 import boto3.session
@@ -108,7 +99,7 @@ class CloudWatchLogHandler(handler_base_class):
                  max_batch_size=1024 * 1024, max_batch_count=10000, boto3_session=None,
                  boto3_profile_name=None, create_log_group=True, log_group_retention_days=None,
                  create_log_stream=True, json_serialize_default=None, *args, **kwargs):
-        handler_base_class.__init__(self, *args, **kwargs)
+        super().__init__(self, *args, **kwargs)
         self.log_group = log_group
         self.stream_name = stream_name
         self.use_queues = use_queues

--- a/watchtower/django.py
+++ b/watchtower/django.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import boto3
 from django.conf import settings
 from watchtower import CloudWatchLogHandler
@@ -29,4 +28,4 @@ class DjangoCloudWatchLogHandler(CloudWatchLogHandler):
 
         kwargs['boto3_session'] = boto3.session.Session(**client_kwargs)
 
-        super(DjangoCloudWatchLogHandler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
Python 2 support stopped on 2020-01-01,
https://devguide.python.org/devcycle/#end-of-life-branches.

Removing support for Python 2.7 reduce testing and maintenance resources
while allowing the library to move towards modern Python conventions.

- Remove mock test dependency. Use unittest.mock instead.
- Remove '-*- coding: utf-8 -*-' encoding marker from source files.
  Source files default to utf-8 in Python 3.
- Remove unnecessary unnecessary __future__ imports.
- Use Python 3 simplified super() syntax.
- Use empty format markers `{}` instead of specifying the
  position-specific `{0}`.

Besides manual inspection, ran the pyupgrade tool to catch additional
upgrades.