### PR TITLE
Automatically discover unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - make install
 
 script:
-  - make test
+  - make coverage
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,16 @@ SHELL=/bin/bash
 
 test_deps:
 	pip install -e .
-	pip install coverage flake8 wheel pyyaml mock boto3
+	pip install flake8 wheel pyyaml mock boto3
 
 lint: test_deps
 	./setup.py flake8
 
 test: test_deps lint
-	coverage run --source=watchtower ./test/test.py
+	python -m unittest
+
+coverage: test_deps lint
+	coverage run -m unittest
 
 init_docs:
 	cd docs; sphinx-quickstart

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL=/bin/bash
 
 test_deps:
+	pip install -e .
 	pip install coverage flake8 wheel pyyaml mock boto3
 
 lint: test_deps

--- a/test/run_logging.py
+++ b/test/run_logging.py
@@ -1,9 +1,5 @@
 import logging
-import os
-import sys
 
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))  # noqa
 from watchtower import CloudWatchLogHandler
 
 handler = CloudWatchLogHandler(stream_name='run_logging')

--- a/test/test.py
+++ b/test/test.py
@@ -22,7 +22,6 @@ import boto3
 import botocore.configloader
 import yaml
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))  # noqa
 from watchtower import CloudWatchLogHandler
 
 USING_PYTHON2 = True if sys.version_info < (3, 0) else False

--- a/test/test.py
+++ b/test/test.py
@@ -139,7 +139,3 @@ class TestPyCWL(unittest.TestCase):
         logger = logging.getLogger("empty")
         logger.addHandler(handler)
         logger.critical("")
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
With the watchtower package being installed, the tests can be automatically
discovered by the unittest runner. This facilitates splitting test modules
and running tests by removing the import guard in the test module.