### PR TITLE
Remove deprecated sudo key from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,4 @@ matrix:
   allow_failures:
     - python: pypy3
 
-sudo: false
 cache: pip


### PR DESCRIPTION
Travis builds report: "deprecated key `sudo` (The key `sudo` has no
effect anymore)".

https://docs.travis-ci.com/user/build-config-validation/#deprecated_key