### PR TITLE
Replace deprecated alias matrix with jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-matrix:
+jobs:
   allow_failures:
     - python: pypy3
 


### PR DESCRIPTION
Travis indicates: key `matrix` is an alias for `jobs`, using `jobs`