### PR TITLE
Add missing travis keys to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,5 @@ matrix:
 
 sudo: false
 cache: pip
+dist: xenial
+os: linux


### PR DESCRIPTION
Travis build complains with:
missing `dist`, using the default `xenial`
missing `os`, using the default `linux`