### PR TITLE
Remove "universal" from [bdist_wheel] section in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,3 @@
-[bdist_wheel]
-universal=1
 [flake8]
 max-line-length=120
 ignore: E301, E401


### PR DESCRIPTION
Now that the package is Python 3 only (since
b9577096f3780b8122ac7cae770093e99e293cfc) the package's wheel is no
longer universal.

A universal wheel is defined as:
https://wheel.readthedocs.io/en/stable/user_guide.html

> If your project contains no C extensions and is expected to work on
> both Python 2 and 3, you will want to tell wheel to produce universal
> wheels …

This project is not compatible with Python 2.