### PR TITLE
Introducing formatter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,6 +156,8 @@ that relies on the default configuration provided by ``boto3``:
     version: 1
     formatters:
         json:
+            (): watchtower.CloudWatchJSONFormatter
+            fields: [msg, levelname]
             format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"
         plaintext:
             format: "[%(asctime)s] %(process)d %(levelname)s %(name)s:%(funcName)s:%(lineno)s - %(message)s"

--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -53,8 +53,8 @@ class CloudWatchFormatter(logging.Formatter):
     :type json_serialize_default: Function
     """
 
-    def __init__(self, fmt=None, datefmt=None, style='%', validate=True, json_serialize_default=None):
-        super(CloudWatchFormatter, self).__init__(fmt=fmt, datefmt=datefmt, style=style, validate=validate)
+    def __init__(self, fmt=None, datefmt=None, json_serialize_default=None, **kwargs):
+        super(CloudWatchFormatter, self).__init__(fmt=fmt, datefmt=datefmt, **kwargs)
 
         self.json_serialize_default = json_serialize_default or _json_serialize_default
 
@@ -79,8 +79,8 @@ class CloudWatchJSONFormatter(logging.Formatter):
     :param fields: A list of fields of the record to include in the CloudWatch Log json object. Defaults to '__all__'.
     :type fields: list
     """
-    def __init__(self, fmt=None, datefmt=None, style='%', validate=True, fields='__all__', json_serialize_default=None):
-        super(CloudWatchJSONFormatter, self).__init__(fmt=fmt, datefmt=datefmt, style=style, validate=validate)
+    def __init__(self, fmt=None, datefmt=None, fields='__all__', json_serialize_default=None, **kwargs):
+        super(CloudWatchJSONFormatter, self).__init__(fmt=fmt, datefmt=datefmt, **kwargs)
 
         self.fields = fields
         self.json_serialize_default = json_serialize_default or _json_serialize_default


### PR DESCRIPTION
Replaced the non-extendable and strict formatting with an extendable logging formatter and also supplied json log formatter that adds support for:
```python
logger.info('Error occurred', extra={
  'user': 'Joe Jones',
  'environment': 'production',
})
```

With the formatter fields argument set to `fields=['msg', 'levelname', 'user', 'environment']` will produce a log with the following json which support metric filter json queries:
```json
{
  "msg": "Error occurred",
  "levelname": "INFO",
  "user": "Joe Jones",
  "environment": "production"
}
```