### PR TITLE
Remove [bdist_wheel] from setup.cfg as Python 2 is not supported

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,3 @@
-[bdist_wheel]
-universal=1
 [flake8]
 max-line-length=120
 ignore: E301, E401


### PR DESCRIPTION
The section:

    [bdist_wheel]
    universal=1

has been removed from setup.cfg. The project has not supported Python 2
since dff1d76a0e9174fc28aefcf5a7b1b26b68ad667e.

As such, the wheel should not be considered "universal".

Per the wheel documentation:

> If your project ... is expected to work on both Python 2 and 3, you
> will want to tell wheel to produce universal wheels by adding this to
> your setup.cfg file:

https://wheel.readthedocs.io/en/stable/user_guide.html