### PR TITLE
Run flake8 through its own command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test_deps:
 	pip install coverage flake8 wheel pyyaml boto3
 
 lint: test_deps
-	./setup.py flake8
+	flake8
 
 test: test_deps lint
 	coverage run --source=watchtower ./test/test.py

--- a/test/run_logging.py
+++ b/test/run_logging.py
@@ -3,8 +3,9 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))  # noqa
-from watchtower import CloudWatchLogHandler
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from watchtower import CloudWatchLogHandler  # noqa: E402
 
 handler = CloudWatchLogHandler(stream_name='run_logging')
 logger = logging.getLogger('run_logging')

--- a/test/test.py
+++ b/test/test.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-import collections
-import copy
 from datetime import datetime
 
 from unittest import mock
@@ -9,7 +7,6 @@ import logging
 import logging.config
 import os
 import os.path
-import re
 import sys
 import tempfile
 import time
@@ -21,9 +18,9 @@ import boto3
 import botocore.configloader
 import yaml
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))  # noqa
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from watchtower import CloudWatchLogHandler, WatchtowerWarning, _idempotent_create
+from watchtower import CloudWatchLogHandler, WatchtowerWarning, _idempotent_create  # noqa: E402
 
 
 class TestPyCWL(unittest.TestCase):


### PR DESCRIPTION
Fixes warning:

> WARNING: flake8 setuptools integration is deprecated and scheduled for
> removal in 4.x. For more information, see
> https://gitlab.com/pycqa/flake8/issues/544

All warnings and errors discovered have been cleaned up.
