### PR TITLE
Move setup information to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,39 @@
+[metadata]
+name = watchtower
+version = 0.8.0
+url = https://github.com/kislyuk/watchtower
+license = Apache Software License
+author = Andrey Kislyuk
+author_email = kislyuk@gmail.com
+description = Python CloudWatch Logging
+long_description = file: README.rst
+classifiers =
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Operating System :: MacOS :: MacOS X
+    Operating System :: POSIX
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: Software Development :: Libraries :: Python Modules
+
+[options]
+include_package_data = true
+packages = find:
+python_requires = >=3.5
+install_requires =
+    boto3 >=1.9.253,<2
+
+[options.packages.find]
+exclude =
+    tests
+
 [flake8]
 max-line-length=120
 ignore: E301, E401

--- a/setup.py
+++ b/setup.py
@@ -1,41 +1,5 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(
-    name="watchtower",
-    version="0.8.0",
-    url="https://github.com/kislyuk/watchtower",
-    license="Apache Software License",
-    author="Andrey Kislyuk",
-    author_email="kislyuk@gmail.com",
-    description="Python CloudWatch Logging",
-    long_description=open("README.rst").read(),
-    python_requires=">=3.5",
-    install_requires=[
-        "boto3 >= 1.9.253, < 2",
-    ],
-    tests_require=[
-        "pyyaml >= 5.3.1, < 6",
-        "flake8 >= 3.7.9, < 4"
-    ],
-    packages=find_packages(exclude=["test"]),
-    platforms=["MacOS X", "Posix"],
-    include_package_data=True,
-    classifiers=[
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: POSIX",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: Software Development :: Libraries :: Python Modules"
-    ]
-)
+setup()


### PR DESCRIPTION
Use a declarative syntax to avoid mixing code and configuration. The
setup.cfg format is easily parsed, opening the possibility for
interaction with tools.

For details on this setuptools feature, see:
https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html