### PR TITLE
Use sys.executable to run Python subprocess in test.py

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -146,7 +146,7 @@ class TestPyCWL(unittest.TestCase):
 
     def test_terminating_process(self):
         cwd = os.path.dirname(__file__)
-        proc = subprocess.Popen(['python', 'run_logging.py'], cwd=cwd)
+        proc = subprocess.Popen([sys.executable, 'run_logging.py'], cwd=cwd)
         proc.wait(10)
 
     def test_empty_message(self):


### PR DESCRIPTION
This ensures that the subprocess always uses the same Python executable
that was used to execute the tests. This is useful when there are
multiple Pythons installed, in a virtual environment, or testing PyPy.

https://docs.python.org/3/library/sys.html#sys.executable