### PR TITLE
Use simpler convenience API subprocess.run()

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -146,8 +146,7 @@ class TestPyCWL(unittest.TestCase):
 
     def test_terminating_process(self):
         cwd = os.path.dirname(__file__)
-        proc = subprocess.Popen(['python', 'run_logging.py'], cwd=cwd)
-        proc.wait(10)
+        subprocess.run(['python', 'run_logging.py'], cwd=cwd, timeout=10, check=True)
 
     def test_empty_message(self):
         handler = CloudWatchLogHandler(use_queues=False)


### PR DESCRIPTION
https://docs.python.org/3/library/subprocess.html#subprocess.run

> The recommended approach to invoking subprocesses is to use the run()
> function for all use cases it can handle.