### PR TITLE
drop support for EOL Python 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Test
 
 on: [push, pull_request]
 
@@ -9,16 +9,18 @@ env:
 
 jobs:
   build:
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       max-parallel: 8
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10.0-alpha - 3.10']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,10 +7,12 @@ version = ""
 release = ""
 language = None
 master_doc = "index"
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.autodoc.typehints", "sphinx.ext.viewcode"]
 source_suffix = [".rst", ".md"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 pygments_style = "sphinx"
+autoclass_content = "both"
+autodoc_typehints = "description"
 
 if "readthedocs.org" in os.getcwd().split("/"):
     with open("index.rst", "w") as fh:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author_email="kislyuk@gmail.com",
     description="Python CloudWatch Logging",
     long_description=open("README.rst").read(),
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=[
         "boto3 >= 1.9.253, < 2",
     ],
@@ -30,7 +30,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Sorry I've been pretty busy focused on other things. The branch had already been updated to include at least some typing and all that needed to be clicked is the "reopen" button. Since that may not have been clear I'm reopening #137 as a new PR.