### PR TITLE
Support for boto3 client config

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -16,6 +16,7 @@ import uuid
 
 import boto3
 import botocore.configloader
+import botocore.config
 import yaml
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -260,6 +261,19 @@ class TestPyCWL(unittest.TestCase):
             logger.error("message")
 
         create_log_stream_mock.assert_not_called()
+
+    def test_client_config_retries(self):
+        config = botocore.config.Config(
+            retries={
+                'max_attempts': 10,
+                'mode': 'standard'
+            }
+        )
+        handler = CloudWatchLogHandler(client_config=config)
+        self.assertDictEqual(
+            handler.cwl_client._client_config.retries,
+            {'mode': 'standard', 'total_max_attempts': 11}
+        )
 
 
 if __name__ == "__main__":

--- a/test/test.py
+++ b/test/test.py
@@ -198,7 +198,7 @@ class TestPyCWL(unittest.TestCase):
         self.assertEqual(
             str(cm.warning),
             "Failed to deliver logs: Parameter validation failed:\n"
-            "Invalid length for parameter logEvents[0].message, value: 0, valid range: 1-inf",
+            "Invalid length for parameter logEvents[0].message, value: 0, valid min length: 1",
         )
 
     def test_create_log_stream_on_emit(self):


### PR DESCRIPTION
Adds support for passing [Boto3's Client Config](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html) into the watchtower constructor. 

The specific use case I'm trying to address is getting the ability to [control the number of retries at the client level](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html#defining-a-retry-configuration-in-a-config-object-for-your-boto3-client). 