### PR TITLE
Update CI config to not fail fast and use more friendly names for CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Test
 
 on: [push, pull_request]
 
@@ -9,8 +9,10 @@ env:
 
 jobs:
   build:
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       max-parallel: 8
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]


### PR DESCRIPTION
Pulling changes out of #144, This changes this:

![Screenshot from 2021-11-15 10-58-42](https://user-images.githubusercontent.com/438813/141761538-400eea95-7d95-4671-9ad4-009d6c42f3c4.png)

To:

![Screenshot from 2021-11-15 10-59-15](https://user-images.githubusercontent.com/438813/141761566-3f107778-4d4f-422c-a951-6edfe749e649.png)

And if you're not familiar with fail-fast, it just means that Python tests are independent of each other.