### PR TITLE
update Sphinx config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,11 +7,12 @@ version = ""
 release = ""
 language = None
 master_doc = "index"
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.autodoc.typehints", "sphinx.ext.viewcode"]
 source_suffix = [".rst", ".md"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 pygments_style = "sphinx"
-autodoc_typehints = "description"
+autoclass_content = "both"
+autodoc_typehints = "both"
 
 if "readthedocs.org" in os.getcwd().split("/"):
     with open("index.rst", "w") as fh:


### PR DESCRIPTION
Pulling changes out of #144 

Fixes this:

![Screenshot from 2021-11-15 10-47-43](https://user-images.githubusercontent.com/438813/141762033-05868b2a-fc22-4e4b-b0cb-c61fd8fdd8a5.png)

To this:

![Screenshot from 2021-11-15 11-01-54](https://user-images.githubusercontent.com/438813/141762074-ea63948c-9d3c-4255-8b86-824040f30277.png)

If you're using Sphinx > 4.1 you can use `autodoc_typehints` as `both` instead of `description` as I had initially put in #144 and you put in ed0d3cc1613ca5d6a5fd97bd7cb3d30fb5e3de0d, if not you should leave `description` since `both` is not understood and will become `signature`.

The `autoclass_content = "both"` does not actually seem like it's _needed_ either anymore or maybe at all, but it's something I've run into before and is confusing that that isn't the default behavior. It will concatenate any docstring in `__init__` and in the class body in order to document the class. There doesn't seem to be any documentation in the `__init__` so it's unneeded, but it doesn't hurt to have so you don't have potentially future documentation get ignored.

See:
- https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autoclass_content
- https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_typehints