### PR TITLE
Fix various log_group / stream_name warnings in tests

### DIFF
--- a/test/logging.yml
+++ b/test/logging.yml
@@ -10,8 +10,8 @@ handlers:
         formatter: json
         level: DEBUG
         (): watchtower.CloudWatchLogHandler
-        log_group: logger
-        stream_name:  loggable
+        log_group_name: logger
+        log_stream_name:  loggable
 loggers:
     root:
         handlers: [watchtower]

--- a/test/logging_profile.yml
+++ b/test/logging_profile.yml
@@ -10,8 +10,8 @@ handlers:
         formatter: json
         level: DEBUG
         (): watchtower.CloudWatchLogHandler
-        log_group: logger
-        stream_name:  loggable
+        log_group_name: logger
+        log_stream_name:  loggable
         boto3_profile_name: watchtowerlogger
 loggers:
     root:

--- a/test/run_logging.py
+++ b/test/run_logging.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 from watchtower import CloudWatchLogHandler  # noqa: E402
 
-handler = CloudWatchLogHandler(stream_name='run_logging')
+handler = CloudWatchLogHandler(log_stream_name='run_logging')
 logger = logging.getLogger('run_logging')
 logger.setLevel(logging.INFO)
 logger.addHandler(handler)

--- a/test/test.py
+++ b/test/test.py
@@ -205,8 +205,8 @@ class TestPyCWL(unittest.TestCase):
         log_group = "py_watchtower_test"
         log_stream = str(uuid.uuid4())
         config_dict = self._make_dict_config(
-            log_group=log_group,
-            stream_name=log_stream,
+            log_group_name=log_group,
+            log_stream_name=log_stream,
             use_queues=False,
         )
         logging.config.dictConfig(config_dict)
@@ -244,8 +244,8 @@ class TestPyCWL(unittest.TestCase):
         log_stream = "existing_" + str(uuid.uuid4())
         logs = boto3.client("logs")
         config_dict = self._make_dict_config(
-            log_group=log_group,
-            stream_name=log_stream,
+            log_group_name=log_group,
+            log_stream_name=log_stream,
             use_queues=False,
         )
         logging.config.dictConfig(config_dict)


### PR DESCRIPTION
Was trying to fix another issue, but noticed a few easy wins for updating the tests to emit fewer warnings, mostly due to: https://github.com/kislyuk/watchtower/blob/616ec967800e86ffaf0c33d29b3f8d62089adcf0/watchtower/__init__.py#L216-L225