### PR TITLE
Add exception capture for CreateLogStream to avoid flush get stuck

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -370,6 +370,13 @@ class CloudWatchLogHandler(logging.Handler):
                             # at this point, the first write to the new stream
                             # should not contain a sequence token at all.
                             kwargs.pop("sequenceToken", None)
+                        except Exception as e2:
+                            # Make sure exception in CreateLogStream not exit
+                            # this thread but conitnue to retry
+                            warnings.warn(
+                                "Failed to create log stream {} when delivering log: {}".format(log_stream_name, e2),
+                                WatchtowerWarning,
+                            )
                         finally:
                             self.creating_log_stream = False
                 else:


### PR DESCRIPTION
Add  exception capture for CreateLogStream,  to avoid flush stuck when CreateLogStream throttle.

This PR is to address some situation mentioned in issue #132 . When CreateLogStream error out in batch mode (`use_queues==True`), e.g. throttle on this action, the `flush()` and `close()` could be stuck at `q.join()`. Because the exception raised during CreateLogStream stopped the log delivering thread, then the queue will never get cleared, then the main thread get stuck.

After adding the exception capture, the log delivering thread would be able to proceed to retry up on CreateLogStream throttle.

This PR only covers one of the causes of stuck I am experiencing. It does not introduce breaking changes, so can be published as patch version.

There might be more reasons causing stuck in `flush()`. It would be better to add a timeout in `flush()`. However, it will change the interface: adding a timeout threshold as a new argument in the class init and/or `flush()`. I will raise a separate PR for it.