### PR TITLE
Replace the deprecated call to `datetime.utcnow()` with `datetime.now(tz.utc)`

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -9,7 +9,7 @@ import threading
 import time
 import warnings
 from collections.abc import Mapping
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from operator import itemgetter
 from typing import Any, Callable, List, Optional, Tuple
 
@@ -314,7 +314,7 @@ class CloudWatchLogHandler(logging.Handler):
             process_id=os.getpid(),
             thread_name=threading.current_thread().name,
             logger_name=message.name,
-            strftime=datetime.utcnow(),
+            strftime=datetime.now(timezone.utc),
         )
 
     def _size(self, msg):


### PR DESCRIPTION
This PR removes uses of the function `datatime.utcnow()` in the function `_get_stream_name` which is [deprecated since python 3.12](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow), and replaces it with `datetime.now(timezone.utc)`. 

Note that this causes a breaking change in a way that the default logged date time will now include the UTC timezone (e.g., `2024-03-10 04:05:38.888377` to `2024-03-10 04:05:38.888377+00:00`), which [is actually preferred](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) to avoid confusions.