### PR TITLE
Add code to support log group tagging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,15 @@ role. While AWS provides no generic managed CloudWatch Logs writer policy, we re
 ``arn:aws:iam::aws:policy/AWSOpsWorksCloudWatchLogs`` managed policy, which has just the right permissions without being
 overly broad.
 
+Log Group Tagging
+~~~~~~~~~~~~~~~~~
+Watchtower supports the tagging of log groups. This can be done by adding the parameter ``log_group_tags`` to the
+``CloudWatchLogHandler`` constructor. This parameter should be a dictionary of tags to apply to the log group.
+
+If you want to add tags to the log group you will need to add permission for the ``logs:TagResource`` action to your
+policy. This will need to be in addition to the AWSOpsWorksCloudWatchLogs policy. (Note: the older ``logs:TagLogGroup``
+permission is for the ``tag_log_group()`` call which is on the path to deprecation and is not used by Watchtower.)
+
 Example: Flask logging with Watchtower
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/test.py
+++ b/test/test.py
@@ -328,10 +328,6 @@ class TestPyCWL(unittest.TestCase):
         log_group_arn = handler._get_log_group_arn()
 
         logs_client = boto3.client("logs")
-        self.addCleanup(
-            logs_client.delete_log_group,
-            logGroupName="test_log_group_tagging",
-        )
 
         logger.critical("This should create a log group with tags")
 

--- a/test/test.py
+++ b/test/test.py
@@ -317,6 +317,28 @@ class TestPyCWL(unittest.TestCase):
 
         self.assertEqual(submit_batch.call_count, 2)
 
+    def test_log_group_tagging(self):
+
+        tags = {"tag1": "value1", "tag2": "value2"}
+        handler = CloudWatchLogHandler(log_group_name="test_log_group_tagging",
+            log_group_tags=tags)
+        logger = logging.getLogger("test_log_group_tagging")
+        logger.addHandler(handler)
+        logger.propagate = False
+        log_group_arn = handler._get_log_group_arn()
+
+        logs_client = boto3.client("logs")
+        self.addCleanup(
+            logs_client.delete_log_group,
+            logGroupName="test_log_group_tagging",
+        )
+
+        logger.critical("This should create a log group with tags")
+
+        tag_list_result = logs_client.list_tags_for_resource(resourceArn=log_group_arn)
+
+        self.assertDictEqual(tag_list_result["tags"], tags)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -182,6 +182,8 @@ class CloudWatchLogHandler(logging.Handler):
         Create CloudWatch Logs log group if it does not exist.  **True** by default.
     :param log_group_retention_days:
         Sets the retention policy of the log group in days.  **None** by default.
+    :param log_group_tags:
+        Tag the log group with the specified tags and values. There is no provision for removing tags. **{}** by default.
     :param create_log_stream:
         Create CloudWatch Logs log stream if it does not exist.  **True** by default.
     :param json_serialize_default:


### PR DESCRIPTION
Add tags to the log group using a parameter when instantiating the CloudWatchLogHandler. Included are: 

- Actual code to do the tagging
- Unit test for the feature
- Updated doctoring and documentation in the README file

(Note: I tried to use `addCleanup() ` to delete the log group associated with the test after it is complete, but test runs kept giving a runtime error that the log stream did not exist. This is likely a race condition somewhere working with AWS so I removed the cleanup function.) 