### PR TITLE
Remove ":" in program_name of log stream name

### DIFF
--- a/watchtower/__init__.py
+++ b/watchtower/__init__.py
@@ -336,7 +336,7 @@ class CloudWatchLogHandler(logging.Handler):
     def _get_stream_name(self, message):
         return self.log_stream_name.format(
             machine_name=self._get_machine_name(),
-            program_name=sys.argv[0],
+            program_name=sys.argv[0].replace(":", ""),
             process_id=os.getpid(),
             thread_name=threading.current_thread().name,
             logger_name=message.name,


### PR DESCRIPTION
## Problem
Windows contains ":" in program_name of log stream name.
For example, `C:\`

log stream name should not have ":" and "*". In regex, [^:*]
So, `sys.argv[0]` causes an error in Windows.

## Solution
Remove all ":" in `sys.argv[0]`
``` python
program_name=sys.argv[0],  # before
program_name=sys.argv[0].replace(":", ""),  # after
```